### PR TITLE
add: figma node -> svg 변환해서 저장

### DIFF
--- a/package.json
+++ b/package.json
@@ -55,7 +55,9 @@
     "file-saver": "^2.0.5",
     "jszip": "^3.10.1",
     "process": "^0.11.10",
+    "punycode": "^1.4.1",
     "stream-browserify": "^3.0.0",
-    "svgicons2svgfont": "^12.0.0"
+    "svgicons2svgfont": "^12.0.0",
+    "webfonts-generator": "^0.4.0"
   }
 }

--- a/package.json
+++ b/package.json
@@ -50,6 +50,7 @@
   },
   "dependencies": {
     "@types/file-saver": "^2.0.7",
+    "@types/svg2ttf": "^5.0.3",
     "@types/svgicons2svgfont": "^10.0.5",
     "buffer": "^6.0.3",
     "file-saver": "^2.0.5",

--- a/package.json
+++ b/package.json
@@ -46,12 +46,12 @@
     "typescript": "^5.4.5",
     "typescript-eslint": "^7.7.0",
     "webpack": "^5.91.0",
-    "webpack-cli": "^5.1.4"
-  },
-  "dependencies": {
+    "webpack-cli": "^5.1.4",
     "@types/file-saver": "^2.0.7",
     "@types/svg2ttf": "^5.0.3",
-    "@types/svgicons2svgfont": "^10.0.5",
+    "@types/svgicons2svgfont": "^10.0.5"
+  },
+  "dependencies": {
     "buffer": "^6.0.3",
     "file-saver": "^2.0.5",
     "jszip": "^3.10.1",

--- a/package.json
+++ b/package.json
@@ -47,5 +47,15 @@
     "typescript-eslint": "^7.7.0",
     "webpack": "^5.91.0",
     "webpack-cli": "^5.1.4"
+  },
+  "dependencies": {
+    "@types/file-saver": "^2.0.7",
+    "@types/svgicons2svgfont": "^10.0.5",
+    "buffer": "^6.0.3",
+    "file-saver": "^2.0.5",
+    "jszip": "^3.10.1",
+    "process": "^0.11.10",
+    "stream-browserify": "^3.0.0",
+    "svgicons2svgfont": "^12.0.0"
   }
 }

--- a/package.json
+++ b/package.json
@@ -49,15 +49,15 @@
     "webpack-cli": "^5.1.4",
     "@types/file-saver": "^2.0.7",
     "@types/svg2ttf": "^5.0.3",
-    "@types/svgicons2svgfont": "^10.0.5"
-  },
-  "dependencies": {
-    "buffer": "^6.0.3",
-    "file-saver": "^2.0.5",
-    "jszip": "^3.10.1",
-    "process": "^0.11.10",
+    "@types/svgicons2svgfont": "^10.0.5",
     "punycode": "^1.4.1",
     "stream-browserify": "^3.0.0",
+    "process": "^0.11.10",
+    "buffer": "^6.0.3"
+  },
+  "dependencies": {
+    "file-saver": "^2.0.5",
+    "jszip": "^3.10.1",
     "svgicons2svgfont": "^12.0.0",
     "webfonts-generator": "^0.4.0"
   }

--- a/src/code.ts
+++ b/src/code.ts
@@ -1,126 +1,52 @@
 import validationChkAction from './utils/input';
-// This file holds the main code for plugins. Code in this file has access to
-// the *figma document* via the figma global object.
-// You can access browser APIs in the <script> tag inside "ui.html" which has a
-// full browser environment (See https://www.figma.com/plugin-docs/how-plugins-run).
-// Runs this code if the plugin is run in Figma
 import drag from './utils/drag';
+import { generateSVGCode, svgsToSvgFont } from './utils/generate';
 import { createVersionPage } from './utils/versionPage';
 
-if (figma.editorType === 'figma') {
-  // This plugin will open a window to prompt the user to enter a number, and
-  // it will then create that many rectangles on the screen.
+figma.showUI(__html__, { width: 360, height: 640 });
+// figma.on('selectionchange', async () => await drag());
 
-  // This shows the HTML page in "ui.html".
-  figma.showUI(__html__, { width: 360, height: 640 });
+// // const postMessage = () => {
+// //   figma.ui.postMessage({
+// //     data: figma.currentPage.selection.length,
+// //   });
 
-  // Calls to "parent.postMessage" from within the HTML page will trigger this
-  // callback. The callback will be passed the "pluginMessage" property of the
-  // posted message.
+// // };
+// // figma.on('selectionchange', postMessage);
 
-  console.log('플러그인이 시작되었습니다.');
+// // postMessage();
+// drag();
 
-  // figma.on('selectionchange', async () => await drag());
+// eslint-disable-next-line no-inner-declarations
 
-  // // const postMessage = () => {
-  // //   figma.ui.postMessage({
-  // //     data: figma.currentPage.selection.length,
-  // //   });
-
-  // // };
-  // // figma.on('selectionchange', postMessage);
-
-  // // postMessage();
-  // drag();
-
-  // eslint-disable-next-line no-inner-declarations
-
-  figma.on('selectionchange', () => {
-    drag();
-  });
-
+figma.on('selectionchange', () => {
   drag();
+});
 
-  figma.ui.onmessage = (msg: { type: string; version: string }) => {
-    if (msg.type === 'create-page') {
-      createVersionPage(msg.version);
-    }
+drag();
 
-    // One way of distinguishing between different types of messages sent from
-    // your HTML page is to use an object with a "type" property like this.
-    // if (msg.type === 'create-shapes') {
-    //   const nodes: SceneNode[] = [];
-    //   for (let i = 0; i < msg.count; i++) {
-    //     const rect = figma.createRectangle();
-    //     rect.x = i * 150;
-    //     rect.fills = [{ type: 'SOLID', color: { r: 1, g: 0.5, b: 0 } }];
-    //     figma.currentPage.appendChild(rect);
-    //     nodes.push(rect);
-    //   }
-    //   figma.currentPage.selection = nodes;
-    //   figma.viewport.scrollAndZoomIntoView(nodes);
-    // }
+figma.ui.onmessage = async (msg: { type: string; version: string }) => {
+  if (msg.type === 'create-page') {
+    createVersionPage(msg.version);
+  }
 
-    // Make sure to close the plugin when you're done. Otherwise the plugin will
-    // keep running, which shows the cancel button at the bottom of the screen.
-    // figma.closePlugin();
-  };
+  const svgList = await generateSVGCode(figma);
+  const test = await svgsToSvgFont(svgList, {
+    fontName: 'test',
+    fontHeight: 1000,
+    normalize: true,
+  });
+  // figma.closePlugin();
+  figma.ui.postMessage({
+    type: 'SVG TEST!!!',
+    data: { svgs: svgList, fontName: 'fontName' },
+  });
+};
 
-  figma.ui.onmessage = (msg: { type: string; isErr: boolean; postVal: string }) => {
-    const rtnVal = validationChkAction(msg.type, msg.isErr, msg.postVal);
-    figma.ui.postMessage({ rtnVal });
-  };
-}
+figma.ui.onmessage = (msg: { type: string; isErr: boolean; postVal: string }) => {
+  const rtnVal = validationChkAction(msg.type, msg.isErr, msg.postVal);
+  figma.ui.postMessage({ rtnVal });
+};
 
-// Runs this code if the plugin is run in FigJam
-if (figma.editorType === 'figjam') {
-  // This plugin will open a window to prompt the user to enter a number, and
-  // it will then create that many shapes and connectors on the screen.
-
-  // This shows the HTML page in "ui.html".
-  figma.showUI(__html__);
-
-  // Calls to "parent.postMessage" from within the HTML page will trigger this
-  // callback. The callback will be passed the "pluginMessage" property of the
-  // posted message.
-
-  figma.ui.onmessage = (msg: { type: string; count: number }) => {
-    // One way of distinguishing between different types of messages sent from
-    // your HTML page is to use an object with a "type" property like this.
-    if (msg.type === 'create-shapes') {
-      const numberOfShapes = msg.count;
-      const nodes: SceneNode[] = [];
-      for (let i = 0; i < numberOfShapes; i++) {
-        const shape = figma.createShapeWithText();
-        // You can set shapeType to one of: 'SQUARE' | 'ELLIPSE' | 'ROUNDED_RECTANGLE' | 'DIAMOND' | 'TRIANGLE_UP' | 'TRIANGLE_DOWN' | 'PARALLELOGRAM_RIGHT' | 'PARALLELOGRAM_LEFT'
-        shape.shapeType = 'ROUNDED_RECTANGLE';
-        shape.x = i * (shape.width + 200);
-        shape.fills = [{ type: 'SOLID', color: { r: 1, g: 0.5, b: 0 } }];
-        figma.currentPage.appendChild(shape);
-        nodes.push(shape);
-      }
-
-      for (let i = 0; i < numberOfShapes - 1; i++) {
-        const connector = figma.createConnector();
-        connector.strokeWeight = 8;
-
-        connector.connectorStart = {
-          endpointNodeId: nodes[i].id,
-          magnet: 'AUTO',
-        };
-
-        connector.connectorEnd = {
-          endpointNodeId: nodes[i + 1].id,
-          magnet: 'AUTO',
-        };
-      }
-
-      figma.currentPage.selection = nodes;
-      figma.viewport.scrollAndZoomIntoView(nodes);
-    }
-
-    // Make sure to close the plugin when you're done. Otherwise the plugin will
-    // keep running, which shows the cancel button at the bottom of the screen.
-    figma.closePlugin();
-  };
-}
+// Make sure to close the plugin when you're done. Otherwise the plugin will
+// keep running, which shows the cancel button at the bottom of the screen.

--- a/src/code.ts
+++ b/src/code.ts
@@ -1,6 +1,11 @@
+// This file holds the main code for plugins. Code in this file has access to
+// the *figma document* via the figma global object.
+// You can access browser APIs in the <script> tag inside "ui.html" which has a
+// full browser environment (See https://www.figma.com/plugin-docs/how-plugins-run).
+// Runs this code if the plugin is run in Figma
 import validationChkAction from './utils/input';
 import drag from './utils/drag';
-import { generateSVGCode, svgsToSvgFont } from './utils/generate';
+import { generateSVGCode, iconToFont, svgsToSvgFont } from './utils/generate';
 import { createVersionPage } from './utils/versionPage';
 
 figma.showUI(__html__, { width: 360, height: 640 });
@@ -18,6 +23,22 @@ figma.showUI(__html__, { width: 360, height: 640 });
 // drag();
 
 // eslint-disable-next-line no-inner-declarations
+// Calls to "parent.postMessage" from within the HTML page will trigger this
+// callback. The callback will be passed the "pluginMessage" property of the
+// posted message.
+figma.ui.onmessage = async (msg: { type: string; version: string }) => {
+  if (msg.type === 'create-page') {
+    // createVersionPage(msg.version);
+  }
+
+  const svgList = await generateSVGCode(figma);
+  const test = await iconToFont(svgList);
+
+  figma.ui.postMessage({
+    type: 'SVG TEST!!!',
+    data: { svgs: svgList, fontName: 'fontName', ...test },
+  });
+};
 
 figma.on('selectionchange', () => {
   drag();
@@ -47,6 +68,3 @@ figma.ui.onmessage = (msg: { type: string; isErr: boolean; postVal: string }) =>
   const rtnVal = validationChkAction(msg.type, msg.isErr, msg.postVal);
   figma.ui.postMessage({ rtnVal });
 };
-
-// Make sure to close the plugin when you're done. Otherwise the plugin will
-// keep running, which shows the cancel button at the bottom of the screen.

--- a/src/code.ts
+++ b/src/code.ts
@@ -1,70 +1,29 @@
-// This file holds the main code for plugins. Code in this file has access to
-// the *figma document* via the figma global object.
-// You can access browser APIs in the <script> tag inside "ui.html" which has a
-// full browser environment (See https://www.figma.com/plugin-docs/how-plugins-run).
-// Runs this code if the plugin is run in Figma
 import validationChkAction from './utils/input';
 import drag from './utils/drag';
 import { generateSVGCode, iconToFont, svgsToSvgFont } from './utils/generate';
 import { createVersionPage } from './utils/versionPage';
 
 figma.showUI(__html__, { width: 360, height: 640 });
-// figma.on('selectionchange', async () => await drag());
+console.log('플러그인이 시작되었습니다.');
 
-// // const postMessage = () => {
-// //   figma.ui.postMessage({
-// //     data: figma.currentPage.selection.length,
-// //   });
-
-// // };
-// // figma.on('selectionchange', postMessage);
-
-// // postMessage();
-// drag();
-
-// eslint-disable-next-line no-inner-declarations
-// Calls to "parent.postMessage" from within the HTML page will trigger this
-// callback. The callback will be passed the "pluginMessage" property of the
-// posted message.
-figma.ui.onmessage = async (msg: { type: string; version: string }) => {
-  if (msg.type === 'create-page') {
-    // createVersionPage(msg.version);
-  }
+figma.ui.onmessage = async (msg: { type: string; isErr: boolean; postVal: string }) => {
+  console.log(msg, 'msg@@@@');
+  const rtnVal = validationChkAction(msg.type, msg.isErr, msg.postVal);
+  figma.ui.postMessage({ type: 'INPUT', data: rtnVal });
 
   const svgList = await generateSVGCode(figma);
   const test = await iconToFont(svgList);
+  console.log('TEST:', test);
 
   figma.ui.postMessage({
-    type: 'SVG TEST!!!',
+    type: 'save-iconfont',
     data: { svgs: svgList, fontName: 'fontName', ...test },
   });
 };
 
 figma.on('selectionchange', () => {
+  console.log('selectChange');
   drag();
 });
 
 drag();
-
-figma.ui.onmessage = async (msg: { type: string; version: string }) => {
-  if (msg.type === 'create-page') {
-    createVersionPage(msg.version);
-  }
-
-  const svgList = await generateSVGCode(figma);
-  const test = await svgsToSvgFont(svgList, {
-    fontName: 'test',
-    fontHeight: 1000,
-    normalize: true,
-  });
-  // figma.closePlugin();
-  figma.ui.postMessage({
-    type: 'SVG TEST!!!',
-    data: { svgs: svgList, fontName: 'fontName' },
-  });
-};
-
-figma.ui.onmessage = (msg: { type: string; isErr: boolean; postVal: string }) => {
-  const rtnVal = validationChkAction(msg.type, msg.isErr, msg.postVal);
-  figma.ui.postMessage({ rtnVal });
-};

--- a/src/ui.ts
+++ b/src/ui.ts
@@ -8,7 +8,7 @@ function saveZip(data: Record<string, any>) {
   const zip = new JSZip();
 
   for (const svg of svgs) {
-    zip?.folder('svg')?.file(`${svg.name}.svg`, svg.code);
+    zip?.folder('svg')?.file(`${svg.metadata.name}.svg`, svg.content);
   }
   zip.generateAsync({ type: 'blob' }).then(function (content) {
     saveAs(content, `${fontName}.zip`);

--- a/src/ui.ts
+++ b/src/ui.ts
@@ -27,7 +27,7 @@ document.addEventListener('DOMContentLoaded', () => {
       window.onmessage = (msg: MessageEvent) => {
         //figma내에서 선택된 요소들 postMessage로 받아옴
         const { data } = msg.data.pluginMessage;
-        console.log(data);
+        console.log(data, 'data@@@@@');
         // zip으로 압축하여 저장
         saveZip(data);
       };

--- a/src/ui.ts
+++ b/src/ui.ts
@@ -27,6 +27,7 @@ document.addEventListener('DOMContentLoaded', () => {
       window.onmessage = (msg: MessageEvent) => {
         //figma내에서 선택된 요소들 postMessage로 받아옴
         const { data } = msg.data.pluginMessage;
+        console.log(data);
         // zip으로 압축하여 저장
         saveZip(data);
       };

--- a/src/ui.ts
+++ b/src/ui.ts
@@ -16,6 +16,7 @@ function saveZip(data: Record<string, any>) {
 }
 
 document.addEventListener('DOMContentLoaded', () => {
+  // btn click event
   const testButton = document.getElementById('generate');
   if (testButton) {
     testButton.onclick = () => {
@@ -23,28 +24,25 @@ document.addEventListener('DOMContentLoaded', () => {
         { pluginMessage: { type: 'create-page', version: '버전 페이지입니다' } },
         '*'
       );
-
-      window.onmessage = (msg: MessageEvent) => {
-        //figma내에서 선택된 요소들 postMessage로 받아옴
-        const { data } = msg.data.pluginMessage;
-        console.log(data, 'data@@@@@');
-        // zip으로 압축하여 저장
-        saveZip(data);
-      };
     };
   } else {
     console.error("Element with id 'test' not found.");
   }
-});
-document.addEventListener('DOMContentLoaded', () => {
-  window.onmessage = (event) => {
-    const pluginMessage = event.data.pluginMessage;
 
+  window.onmessage = (msg: MessageEvent) => {
+    const pluginMessage = msg.data.pluginMessage;
+    console.log('DATA@@@@@ :', pluginMessage);
+
+    //figma내에서 선택된 요소들 postMessage로 받아옴
     if (pluginMessage && pluginMessage.type === 'selected-svgs') {
       const countBadge = document.getElementById('count-badge');
       if (countBadge) {
         countBadge.textContent = `${pluginMessage.svgs.length}`;
       }
+    }
+    if (pluginMessage.type === 'save-iconfont') {
+      // zip으로 압축하여 저장
+      saveZip(pluginMessage.data);
     }
   };
 });

--- a/src/ui.ts
+++ b/src/ui.ts
@@ -1,4 +1,19 @@
 import './ui.css';
+import JSZip from 'jszip';
+import { saveAs } from 'file-saver';
+
+// figma.on 내에서 사용 불가
+function saveZip(data: Record<string, any>) {
+  const { fontName, svgs } = data;
+  const zip = new JSZip();
+
+  for (const svg of svgs) {
+    zip?.folder('svg')?.file(`${svg.name}.svg`, svg.code);
+  }
+  zip.generateAsync({ type: 'blob' }).then(function (content) {
+    saveAs(content, `${fontName}.zip`);
+  });
+}
 
 document.addEventListener('DOMContentLoaded', () => {
   const testButton = document.getElementById('generate');
@@ -8,6 +23,13 @@ document.addEventListener('DOMContentLoaded', () => {
         { pluginMessage: { type: 'create-page', version: '버전 페이지입니다' } },
         '*'
       );
+
+      window.onmessage = (msg: MessageEvent) => {
+        //figma내에서 선택된 요소들 postMessage로 받아옴
+        const { data } = msg.data.pluginMessage;
+        // zip으로 압축하여 저장
+        saveZip(data);
+      };
     };
   } else {
     console.error("Element with id 'test' not found.");

--- a/src/utils/generate.ts
+++ b/src/utils/generate.ts
@@ -1,7 +1,7 @@
 import SVGIcons2SVGFontStream from 'svgicons2svgfont';
-import webfontsGenerator from 'webfonts-generator';
+// import webfontsGenerator from 'webfonts-generator';
 import { Readable, Writable } from 'stream';
-import saveZip from './download';
+// import saveZip from './download';
 interface ReadableWithMetadata extends Readable {
   metadata?: {
     unicode: string[];
@@ -14,11 +14,18 @@ export async function generateSVGCode(target = figma) {
   // const svgs = getselectedItems(target);
   const svgs = target.currentPage.selection;
   const svgCodeList = await Promise.all(
-    svgs.map(async (svg) => {
-      const convertSVG = await svg.exportAsync({
+    svgs.map(async (svg, idx) => {
+      const glyph = await svg.exportAsync({
         format: 'SVG_STRING',
       });
-      return { name: svg.name, code: convertSVG };
+
+      return {
+        content: glyph,
+        metadata: {
+          name: svg.name,
+          unicode: [String.fromCharCode(0xea01 + idx)],
+        },
+      };
     })
   );
 
@@ -106,12 +113,30 @@ export async function svgsToSvgFont(svgs: any, options: any) {
 
   const svgFontBuffer = Buffer.concat(buffers);
 
-  const fonts = await webfontsGenerator({
-    files: [svgFontBuffer],
-    fontName: 'testName',
-    types: ['ttf', 'woff', 'woff2', 'eot', 'svg'],
-    writeFiles: false, // Do not write to disk
-  });
+  // const fonts = await webfontsGenerator({
+  //   files: [svgFontBuffer],
+  //   fontName: 'testName',
+  //   types: ['ttf', 'woff', 'woff2', 'eot', 'svg'],
+  //   writeFiles: false, // Do not write to disk
+  // });
 
-  saveZip(fonts);
+  // saveZip(fonts);
 }
+
+// TODO: 추후 타입 정의 필요 일단 급해서 any 처리
+export const iconToFont = async (svgList: any) => {
+  const svgFont = await svgsToSvgFont(svgList, {
+    fontName: 'test',
+    fontHeight: 1000,
+    normalize: true,
+  });
+  const ttf = svgFontToTTF(svgFont as unknown as string);
+
+  return {
+    ttf,
+  };
+};
+
+export const svgFontToTTF = (svgFont: string) => {
+  // return Buffer.from(svg2ttf(svgFont, { copyright: 'test' }).buffer);
+};

--- a/src/utils/generate.ts
+++ b/src/utils/generate.ts
@@ -1,0 +1,45 @@
+import SVGIcons2SVGFontStream from 'svgicons2svgfont';
+import { getselectedItems } from './versionPage';
+import { Readable } from 'stream';
+
+// figma node -> svg로 변환
+export async function generateSVGCode(target = figma) {
+  const svgs = getselectedItems(target);
+
+  const svgCodeList = await Promise.all(
+    svgs.map(async (svg) => {
+      const convertSVG = await svg.exportAsync({
+        format: 'SVG_STRING',
+      });
+      return { name: svg.name, code: convertSVG };
+    })
+  );
+
+  return svgCodeList;
+}
+
+// svg -> IconFont 변환
+export function svgsToSvgFont(svgs: any, options: any) {
+  let result = '';
+  const fontStream = new SVGIcons2SVGFontStream(options)
+    .on('end', () => {
+      console.log('RESULT: ', result);
+    })
+    .on('data', (data) => {
+      result += data;
+      console.log('DATA:', data);
+    })
+    .on('error', (err) => console.log('ERROR:', err));
+
+  for (const svg of svgs) {
+    console.log('SVG: ', svg);
+    // fs모듈
+    const svgStream = new Readable();
+    svgStream.push(svg.code);
+    svgStream.push(null); // 왜 넣는거주ㅣ../?
+
+    fontStream.write(svgStream);
+  }
+
+  fontStream.end();
+}

--- a/src/utils/generate.ts
+++ b/src/utils/generate.ts
@@ -1,7 +1,7 @@
 import SVGIcons2SVGFontStream from 'svgicons2svgfont';
 import webfontsGenerator from 'webfonts-generator';
 import { Readable, Writable } from 'stream';
-
+import saveZip from './download';
 interface ReadableWithMetadata extends Readable {
   metadata?: {
     unicode: string[];
@@ -112,4 +112,6 @@ export async function svgsToSvgFont(svgs: any, options: any) {
     types: ['ttf', 'woff', 'woff2', 'eot', 'svg'],
     writeFiles: false, // Do not write to disk
   });
+
+  saveZip(fonts);
 }

--- a/src/utils/generate.ts
+++ b/src/utils/generate.ts
@@ -96,10 +96,11 @@ export async function svgsToSvgFont(svgs: any, options: any) {
     .on('error', (err) => console.log('stream err on generate.ts 88', err));
 
   for (const svg of svgs) {
-    // console.log('SVG: ', svg);
-    const glyph = createStreamFromString(svg.code, {
+    console.log('SVG: ', svg);
+    const { metadata, content } = svg;
+    const glyph = createStreamFromString(content, {
       unicode: ['\uE001'],
-      name: svg.name,
+      name: metadata.name,
     });
     fontStream.write(glyph);
   }
@@ -107,11 +108,11 @@ export async function svgsToSvgFont(svgs: any, options: any) {
   fontStream.end();
 
   // Capture the output of SVGIcons2SVGFontStream into a buffer
-  const buffers: Buffer[] = [];
-  fontStream.on('data', (chunk) => buffers.push(chunk));
-  await new Promise((resolve) => fontStream.on('end', resolve));
+  // const buffers: Buffer[] = [];
+  // fontStream.on('data', (chunk) => buffers.push(chunk));
+  // await new Promise((resolve) => fontStream.on('end', resolve));
 
-  const svgFontBuffer = Buffer.concat(buffers);
+  // const svgFontBuffer = Buffer.concat(buffers);
 
   // const fonts = await webfontsGenerator({
   //   files: [svgFontBuffer],
@@ -130,6 +131,8 @@ export const iconToFont = async (svgList: any) => {
     fontHeight: 1000,
     normalize: true,
   });
+
+  console.log(svgFont, 'svgfont');
   const ttf = svgFontToTTF(svgFont as unknown as string);
 
   return {

--- a/src/utils/versionPage.ts
+++ b/src/utils/versionPage.ts
@@ -17,7 +17,6 @@ export function getselectedItems(target = figma) {
   return layersToCopy.map((layer) => layer.clone());
 }
 
-// @see https://github.com/destefanis/Discord-Figma-Project-Scaffold
 export const createVersionPage = async (title: string, target = figma) => {
   const items = getselectedItems(target);
   const versionPage = createPage(title, target);

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -6,6 +6,8 @@
     "noImplicitAny": true /* 명시적이지 않은 'any' 유형으로 표현식 및 선언 사용 시 오류 발생 */,
     "strictNullChecks": true /* 엄격한 null 검사 사용 */,
     "strictFunctionTypes": true /* 엄격한 함수 유형 검사 사용 */,
+    "moduleResolution": "node",
+    "allowSyntheticDefaultImports": true,
     "typeRoots": ["./node_modules/@types", "./node_modules/@figma", "dist"]
   },
   "include": ["src/**/*"],

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -35,6 +35,7 @@ module.exports = (env, argv) => ({
       stream: require.resolve('stream-browserify'),
       buffer: require.resolve('buffer/'),
       process: require.resolve('process/browser'),
+      string_decoder: require.resolve('string_decoder'),
     },
   },
 
@@ -56,6 +57,7 @@ module.exports = (env, argv) => ({
     }),
     new webpack.ProvidePlugin({
       process: 'process/browser', // Ensures process is globally available
+      Buffer: ['buffer', 'Buffer'],
     }),
   ],
 });

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -29,7 +29,14 @@ module.exports = (env, argv) => ({
   },
 
   // Webpack tries these extensions for you if you omit the extension like "import './file'"
-  resolve: { extensions: ['.ts', '.js'] },
+  resolve: {
+    extensions: ['.ts', '.js'],
+    fallback: {
+      stream: require.resolve('stream-browserify'),
+      buffer: require.resolve('buffer/'),
+      process: require.resolve('process/browser'),
+    },
+  },
 
   output: {
     filename: '[name].js',
@@ -46,6 +53,9 @@ module.exports = (env, argv) => ({
     }),
     new HtmlInlineScriptPlugin({
       assetPreservePattern: [/ui.js/],
+    }),
+    new webpack.ProvidePlugin({
+      process: 'process/browser', // Ensures process is globally available
     }),
   ],
 });


### PR DESCRIPTION
작업내용
1. svgicons2svgfont 라이브러리 사용 테스트
 - fontStream 생성까지는 했으나 fontStream.write() 부분에서 decode 에러 발생
 ㄴ Node 모듈은 figma.on 내에서 사용 불가능이라 webpack에 string_decoder 폴리필 해주었으나.. 해결 x ㅜㅜ 
3. jsZip, file-saver 라이브러리 테스트, figma node -> svg로 변환하여 압축 저장 완료